### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ class MyTest(unittest.TestCase):
         from google.appengine.api import taskqueue
         task_url = '/some/task'
         taskqueue.add(url=task_url)
-        stub = self.testbed.get_stub('taskqueue')
-        tasks = self.taskqueue_stub.get_filtered_tasks(url=task_url)
+        taskqueue_stub = self.testbed.get_stub('taskqueue')
+        tasks = taskqueue_stub.get_filtered_tasks(url=task_url)
         self.assertEqual(1, len(tasks))
         self.assertEqual(task_url, tasks[0].url)
 ```


### PR DESCRIPTION
Fix "object has no attribute 'taskqueue_stub'" when running nosetests --with-gae on the code underlying test_using_taskqueue.
